### PR TITLE
Fix voting power calculation error

### DIFF
--- a/apis/cosmos-reducers.js
+++ b/apis/cosmos-reducers.js
@@ -621,7 +621,7 @@ export function getValidatorUptimePercentage(validator, signedBlocksWindow) {// 
   }
 }
 
-export function validatorReducer(validator, annualProvision, supply, pool) {
+export function validatorReducer(validator, annualProvision, totalShares, pool) {
   const statusInfo = getValidatorStatus(validator)
   let websiteURL = validator.description.website
   if (!websiteURL || websiteURL === '[do-not-modify]') {
@@ -644,7 +644,7 @@ export function validatorReducer(validator, annualProvision, supply, pool) {
     website: websiteURL,
     identity: validator.description.identity,
     name: validator.description.moniker,
-    votingPower: (validator.tokens / supply).toFixed(6),
+    votingPower: validator.status === 3 ? (validator.delegator_shares / totalShares).toFixed(6) : '0',
     startHeight: validator.signing_info
       ? validator.signing_info.start_height
       : undefined,

--- a/apis/cosmos-source.js
+++ b/apis/cosmos-source.js
@@ -209,16 +209,17 @@ export default class CosmosAPI {
     const [
       validators,
       annualProvision,
-      supply,
       pool
     ] = await Promise.all([
       this.query(`staking/validators?status=BOND_STATUS_BONDED`),
       this.getAnnualProvision().catch(() => undefined),
-      this.getStakingSupply(),
       this.query(`cosmos/staking/v1beta1/pool`)
     ])
-    return validators.result.map(validator => reducers.validatorReducer(validator, annualProvision, supply, pool))
-
+    const totalShares = validators.result.reduce(
+      (sum, { delegator_shares: delegatorShares }) => sum.plus(delegatorShares),
+      BigNumber(0)
+    )
+    return validators.result.map(validator => reducers.validatorReducer(validator, annualProvision, totalShares, pool))
   }
 
   async getInflation() {

--- a/apis/cosmos-source.js
+++ b/apis/cosmos-source.js
@@ -201,10 +201,6 @@ export default class CosmosAPI {
     await this.dataReady
     return Object.values(this.validators)
   }
-  async getStakingSupply() {
-    const res = await this.query(`cosmos/bank/v1beta1/supply`)
-    return BigNumber(res.supply[0].amount)
-  }
   async loadValidators() {
     const [
       validators,


### PR DESCRIPTION
### Background
There is only one validator in a testnet, the voting power of this validator is expected to be 100% but got 8.21%.

### Cause
The original voting power calculation uses `supply`(total supply) gotten from the `getStakingSupply` function as the denominator and `token` of each validator as the numerator. But should use `delegator_shares` of active validator as the denominator and its sum as the numerator.

### Revision
- Use the amount of `delegator_shares` of each active validator divides its sum to calculate the voting power.
- Delete unused function `getStakingSupply`.