### PR TITLE
Fix inactive validators not displayed error

### DIFF
--- a/apis/cosmos-source.js
+++ b/apis/cosmos-source.js
@@ -207,18 +207,24 @@ export default class CosmosAPI {
   }
   async loadValidators() {
     const [
-      validators,
+      { result: bondedValidators },
+      { result: unbondingValidators },
+      { result: unbondedValidators },
+      { result: unspecifiedValidators },
       annualProvision,
       supply,
       pool
     ] = await Promise.all([
       this.query(`staking/validators?status=BOND_STATUS_BONDED`),
+      this.query(`staking/validators?status=BOND_STATUS_UNBONDING`),
+      this.query(`staking/validators?status=BOND_STATUS_UNBONDED`),
+      this.query(`staking/validators?status=BOND_STATUS_UNSPECIFIED`),
       this.getAnnualProvision().catch(() => undefined),
       this.getStakingSupply(),
       this.query(`cosmos/staking/v1beta1/pool`)
     ])
-    return validators.result.map(validator => reducers.validatorReducer(validator, annualProvision, supply, pool))
-
+    const allValidators = bondedValidators.concat(unbondingValidators, unbondedValidators, unspecifiedValidators)
+    return allValidators.map(validator => reducers.validatorReducer(validator, annualProvision, supply, pool))
   }
 
   async getInflation() {


### PR DESCRIPTION
### Background
Some of the validators in a testnet are offline, they should be labeled as **inactive** in the validator list. But they are not displayed.

### Cause
The `loadValidators` function only fetches active validators(`status === 'BOND_STATUS_BONDED'`).

### Revision
- The `staking/validators` endpoint get the validators with `status === 'BOND_STATUS_BONDED'` by default if the `status` parameter is not specified. So we should explicitly get inactive validators including `status` in `BOND_STATUS_UNBONDING`, `BOND_STATUS_UNBONDED`, and `BOND_STATUS_UNSPECIFIED` seperately, which covers all the `status` enum.
- Put inactive validators in the array to display.